### PR TITLE
fix: 修复参数位置, 修复400错误

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -145,8 +145,9 @@ export async function summarize(roomName: string, apiKey: string):Promise<void |
    * The raw data to be sent to the Dify.ai API.
    */
   const raw = JSON.stringify({
-    inputs: {},
-    query: `<input>${fileContent.slice(-80000)}</input>`,
+    inputs: {
+      query: `<input>${fileContent.slice(-80000)}</input>`,
+    },
     response_mode: 'blocking',
     user: 'abc-123',
   }); 

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -148,6 +148,7 @@ export async function summarize(roomName: string, apiKey: string):Promise<void |
     inputs: {
       query: `<input>${fileContent.slice(-80000)}</input>`,
     },
+    query: `<input>${fileContent.slice(-80000)}</input>`,
     response_mode: 'blocking',
     user: 'abc-123',
   }); 


### PR DESCRIPTION
本地调试了一下 ，发现请求一直报错，查看了文档发现 请求参数中的query字段应该放在 input 下面. 
配置zhong中的 query 需要打开


<img width="1245" alt="image" src="https://github.com/aoao-eth/wechat-ai-summarize-bot/assets/34591322/d818ada6-d903-4972-b2ce-d0657fa5ec93">
