### PR TITLE
锁死micriosoft的speech sdk，否则有几率报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "lodash": "^4.17.21",
-    "microsoft-cognitiveservices-speech-sdk": "^1.32.0",
+    "microsoft-cognitiveservices-speech-sdk": "1.32.0",
     "moment": "^2.29.4",
     "qrcode-terminal": "^0.12.0",
     "wechaty": "^1.19.10",


### PR DESCRIPTION
yarn run v1.22.19
$ nextron
[nextron] Run renderer process: next -p 8888 renderer [nextron] Run main process: electron . 8888 --remote-debugging-port=5858 --inspect=9292 App threw an error during load
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/kalaliu/work/wechat-ai-summarize-bot/app/node_modules/microsoft-cognitiveservices-speech-sdk/distrib/lib/microsoft.cognitiveservices.speech.sdk.js from /Users/kalaliu/work/wechat-ai-summarize-bot/app/app/background.js not supported. Instead change the require of microsoft.cognitiveservices.speech.sdk.js in /Users/kalaliu/work/wechat-ai-summarize-bot/app/app/background.js to a dynamic import() which is available in all CommonJS modules.
    at c._load (node:electron/js2c/asar_bundle:5:13343)
    at webpackUniversalModuleDefinition (/Users/kalaliu/work/wechat-ai-summarize-bot/app/app/background.js:3:100)
    at Object.<anonymous> (/Users/kalaliu/work/wechat-ai-summarize-bot/app/app/background.js:10:3)
    at c._load (node:electron/js2c/asar_bundle:5:13343)
    at loadApplicationPackage (/Users/kalaliu/work/wechat-ai-summarize-bot/app/node_modules/electron/dist/Electron.app/Contents/Resources/default_app.asar/main.js:121:16)
    at Object.<anonymous> (/Users/kalaliu/work/wechat-ai-summarize-bot/app/node_modules/electron/dist/Electron.app/Contents/Resources/default_app.asar/main.js:233:9)
    at c._load (node:electron/js2c/asar_bundle:5:13343)
    at Object.<anonymous> (node:electron/js2c/browser_init:189:3102)
    at ./lib/browser/init.ts (node:electron/js2c/browser_init:189:3306)
    at __webpack_require__ (node:electron/js2c/browser_init:1:128)
    at node:electron/js2c/browser_init:1:1200
    at node:electron/js2c/browser_init:1:1267
    at c._load (node:electron/js2c/asar_bundle:5:13343)